### PR TITLE
Read the whole thing, don't be lazy

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -65,6 +65,11 @@ export default {
 </script>
 
 <style>
+
+  * {
+    -webkit-print-color-adjust: exact;
+  }
+
   #app {
     background: url('assets/background.jpg');
     background-size: 100% 100%;
@@ -103,11 +108,11 @@ export default {
   }
 
   .iceBlueBackgroundButton {
-    background: rgb(52, 145, 173, 0.9) !important;
+    background: #4695EC !important;
   }
 
   .scrimmageButtonSelected {
-    background: rgba(52, 145, 173, 0.8) !important;
+    background: #4695EC !important;
     transition: background 0s;
     -moz-transition: background 0s;
     -webkit-transition: background 0s;
@@ -117,7 +122,8 @@ export default {
   /* undoing the animation effect that v-btn uses which looked bad */
   .scrimmageButton--active:before, .scrimmageButton:focus:before, .scrimmageButton:hover:before {
     background-color: rgba(0,0,0,0) !important;
-}
+  }
+  
 
 
 </style>

--- a/src/components/scrimmage/events/Events.vue
+++ b/src/components/scrimmage/events/Events.vue
@@ -2,7 +2,17 @@
   <div id="events" class="events">
   <v-card class="translucentBackground scrimmageBorder events-card">
     <v-container class="pa-0" fluid>
-      <h2 class="text-xs-center bottomScrimmageBorder py-2">Event log</h2>
+        <v-layout class="bottomScrimmageBorder py-2 pl-3 pr-4">
+          <v-flex class="mt-1">
+            <h2>Event log</h2>
+          </v-flex>
+          <v-flex xs2>
+            <v-btn class="ma-0" color="blue" flat icon :to="{path: '/events', params: {}}">
+              <v-icon medium>exit_to_app</v-icon>
+            </v-btn>
+        </v-flex>
+        </v-layout>
+
         <Event v-for="(eventItem, i) in occurredEvents.slice().reverse()"
         v-bind:data="eventItem"
         v-bind:key="i"

--- a/src/components/scrimmage/events/EventsSummary.vue
+++ b/src/components/scrimmage/events/EventsSummary.vue
@@ -1,0 +1,42 @@
+<template>
+    <v-data-table
+        :headers="headers"
+        :items="this.$store.getters.getEventList.reverse()" 
+        hide-actions
+        class="elevation-1 scrimmageBorder"
+    >
+      <template slot="items" slot-scope="props">
+        <td class="text-xs-center">{{ props.item.player }}</td>
+        <td class="text-xs-center">{{ props.item.action }}</td>
+        <td class="text-xs-center">{{ "x: "+ Math.round(props.item.position.x) + "&emsp;" + 
+            "y: "+Math.round(props.item.position.y)}}</td>
+        <td class="text-xs-center">{{ props.item.timeStamp }}</td>
+      </template>
+    </v-data-table>
+</template>
+
+<script>
+import Vue from "vue";
+export default {
+  data() {
+    return {
+      headers: [
+        { text: "Player", align: "center", value: "player" },
+        { text: "Action", align: "center", value: "action" },
+        { text: "Position", align: "center", value: "position", sortable:false },
+        { text: "Time", align: "center", value: "timeStamp" }
+      ],
+    };
+  },
+  /* manually styling bc vuetify doesn't expose the relevant HTML element */
+  mounted: function() {
+    document.getElementsByTagName("table")[0].className +=
+      " " + "translucentBackground";
+  }
+};
+</script>
+
+<style>
+    @media print{@page {size: landscape}; nav {display:none;}}
+    
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ import Settings from '../components/settings/Settings'
 import Clock from '../components/settings/Clock'
 import Team from '../components/Team/Team'
 import ScrimmageApp from '../components/scrimmage/ScrimmageApp'
+import EventsSummary from '../components/scrimmage/events/EventsSummary'
 
 Vue.use(Router)
 
@@ -51,6 +52,11 @@ const router = new Router({
       path: '/scrimmage',
       name: 'Scrimmage',
       component: ScrimmageApp
+    },
+    {
+      path: '/events',
+      name: 'EventsSummary',
+      component: EventsSummary
     }
   ]
 })


### PR DESCRIPTION
Added an event summary page that looks like this.
<img width="1679" alt="screen shot 2018-08-04 at 10 40 47 pm" src="https://user-images.githubusercontent.com/30158361/43682354-49ed630a-9838-11e8-9c2a-6985bdf26fa3.png">

When you try to print it, this is how it looks.
<img width="999" alt="screen shot 2018-08-04 at 10 40 37 pm" src="https://user-images.githubusercontent.com/30158361/43682357-69ea5a82-9838-11e8-9a7c-c8aa09b45827.png">

On the scrimmage app page, you click on the blue icon near "Event Log" to take you to this page. Approve the PR for now, and we can discuss in Monday's meeting the workflow for this feature (will it end the scrimmage? will it open in a new tab or same window? etc.)
<img width="1680" alt="screen shot 2018-08-04 at 10 40 54 pm" src="https://user-images.githubusercontent.com/30158361/43682370-ac52be82-9838-11e8-83bf-0c0a214d7243.png">

Side note: Also removed the "ice blue" color for now to make it all joe's favorite blue color, the material design one. consistency >>>